### PR TITLE
 Fix sepolicy denial for

### DIFF
--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -10,3 +10,5 @@ allow system_server sysfs_devices_sensors:file rw_file_perms;
 allow system_server sysfs_devices_sensors:lnk_file read;
 
 allow system_server sysfs_usb_supply:lnk_file read;
+
+allow system_server qti_debugfs:file { read open getattr };


### PR DESCRIPTION
1.avc: denied { read } for uid=1000 name="mem" dev="debugfs" ino=75333 scontext=u:r:system_server:s0 tcontext=u:object_r:qti_debugfs:s0 tclass=file permissive=1
2.avc: denied { open } for uid=1000 name="mem" dev="debugfs" ino=75333 scontext=u:r:system_server:s0 tcontext=u:object_r:qti_debugfs:s0 tclass=file permissive=1
3.avc: denied { getattr } for uid=1000 path="/sys/kernel/debug/kgsl/proc/1740/mem" dev="debugfs" ino=75333 scontext=u:r:system_server:s0 tcontext=u:object_r:qti_debugfs:s0 tclass=file permissive=1